### PR TITLE
Fix minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ RUBY_APPLY_PATCHES=$(curl -s https://raw.githubusercontent.com/rvm/rvm/master/pa
 Running `rtx plugin-update ruby` will update rtx-ruby and ensure the latest versions of ruby are available to install. By default rtx-ruby uses the latest release of ruby-build, however instead you can choose your own branch/tag through the `RTX_RUBY_BUILD_VERSION` variable:
 
 ```
-RTX_RUBY_BUILD_VERSION=master rtx install ruby 2.6.4
+RTX_RUBY_BUILD_VERSION=master rtx install ruby@2.6.4
 ```
 
 ## Default gems


### PR DESCRIPTION
Corrects things for installing specific versions with latest ruby-build

Syntax is a bit different than the upstream asdf.

```
RTX_RUBY_BUILD_VERSION=master rtx install 2.6.4
rtx No repository found for plugin 2.6.4
rtx Run with RTX_DEBUG=1 for more information
```